### PR TITLE
chore: make install_requires the same value as requirements.txt.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,11 @@ from os import path
 
 from setuptools import setup
 
+
+def _requires_from_file(filename):
+    return open(filename).read().splitlines()
+
+
 about = {}
 with open("japanera/__about__.py") as f:
     exec(f.read(), about)
@@ -42,7 +47,7 @@ setup(name=about["__title__"],
       description=about["__description__"],
       long_description=__doc__,
       long_description_content_type="text/markdown",
-      install_requires=["kanjize==1.4.0"],
+      install_requires=_requires_from_file('requirements.txt'),
       packages=["japanera"],
       zip_safe=False,
       setup_requires=['wheel'],


### PR DESCRIPTION
いつもお世話になっております。
大変、便利なライブラリと思い、ご利用しています 🙇 

renovateでライブラリのバージョンアップを行っているのですが、
JapaneraがKanjize=1.5.0のアップデートを拒んでいたため、こちらのIssueと似たような事象を確認していました。

- https://github.com/nagataaaas/Japanera/issues/10

そこで、このIssueに対応してみました 🙋 

なお、このようにPublicなライブラリにコミットするのははじめてなため、ご無礼をお許しください

## 確認事項

- pip install で、Kanjize=1.5.0がインストールされること

```sh
$ pip install .
$ pip list
Package    Version
---------- -------
Japanera   2.1.1
kanjize    1.5.0
pip        23.1.2
setuptools 65.5.0
```

- 各種テストの通過
```sh
$ python -m unittest tests/*.py
```
